### PR TITLE
Copy the Maven publish repos everywhere

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,6 +1,7 @@
 import groovy.lang.GroovyObject
 import org.jfrog.gradle.plugin.artifactory.dsl.ArtifactoryPluginConvention
 import org.jfrog.gradle.plugin.artifactory.dsl.PublisherConfig
+import java.net.URI
 
 plugins {
     `kotlin-dsl`
@@ -82,6 +83,19 @@ configure<ArtifactoryPluginConvention> {
             setProperty("password", resolveProperty("ARTIFACTORY_PASSWORD", "artifactoryPassword"))
         })
     })
+}
+
+configure<PublishingExtension> {
+    repositories {
+        maven {
+            name = "remote"
+            url = URI(resolveProperty("ARTIFACTORY_URL", "artifactoryUrl"))
+            credentials {
+                username = resolveProperty("ARTIFACTORY_USER", "artifactoryUser")
+                password = resolveProperty("ARTIFACTORY_PASSWORD", "artifactoryPassword")
+            }
+        }
+    }
 }
 
 project.afterEvaluate {

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -87,42 +87,7 @@ configure<ArtifactoryPluginConvention> {
 
 configure<PublishingExtension> {
     repositories {
-
-        val artiUrl = resolveProperty("ARTIFACTORY_URL", "artifactoryUrl")
-        if (artiUrl != null) {
-            maven {
-                name = "artifactory"
-                url = URI.create(artiUrl)
-                credentials {
-                    username = resolveProperty("ARTIFACTORY_USER", "artifactoryUser")
-                    password = resolveProperty("ARTIFACTORY_PASSWORD", "artifactoryPassword")
-                }
-            }
-        }
-
-        val gitlabUrl = resolveProperty("GITLAB_URL", "gitlabUrl")
-        if (gitlabUrl != null) {
-            maven {
-                name = "gitlab"
-                url = URI.create(gitlabUrl)
-                credentials(org.gradle.api.credentials.HttpHeaderCredentials::class, Action {
-                    // Token specified by
-                    val jobToken = System.getenv("CI_JOB_TOKEN")
-                    if (jobToken != null) {
-                        name = "Job-Token"
-                        value = jobToken
-                    } else {
-                        name = "Private-Token"
-                        value = resolveProperty("GITLAB_TOKEN", "gitlabToken")
-                    }
-                })
-            }
-        }
-
-        val releasesRepoUrl = resolveProperty("MAVEN_RELEASES_REPO_URL", "mavenReleasesRepoUrl")
-        val snapshotsRepoUrl = resolveProperty("MAVEN_SNAPSHOTS_REPO_URL", "mavenSnapshotsRepoUrl")
-        val chosenUrl =
-                (if (hasProperty("release")) releasesRepoUrl else snapshotsRepoUrl)
+        val chosenUrl = resolveProperty("MAVEN_REPO_URL", "mavenRepoUrl")
         if (chosenUrl != null) {
              maven {
                 url = URI.create(chosenUrl)
@@ -133,7 +98,6 @@ configure<PublishingExtension> {
                 }
             }
         }
-
     }
 }
 

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -1,3 +1,8 @@
-
+pluginManagement {
+    repositories {
+        jcenter()
+        gradlePluginPortal()
+    }
+}
 
 rootProject.name = "omero-artifact-plugin"

--- a/src/main/kotlin/org/openmicroscopy/AdditionalRepositoriesPlugin.kt
+++ b/src/main/kotlin/org/openmicroscopy/AdditionalRepositoriesPlugin.kt
@@ -2,13 +2,25 @@ package org.openmicroscopy
 
 import org.gradle.api.Plugin
 import org.gradle.api.Project
+import org.gradle.api.artifacts.repositories.MavenArtifactRepository
+import org.gradle.kotlin.dsl.closureOf
 import org.gradle.kotlin.dsl.repositories
+import org.openmicroscopy.PluginHelper.Companion.resolveProperty
 import java.net.URI
 
 class AdditionalRepositoriesPlugin : Plugin<Project> {
     override fun apply(project: Project): Unit = project.run {
         repositories {
-            // Add openmicroscopy atrifactory as a repository for
+            // Add artifactory and maven repositories if defined
+            closureOf<MavenArtifactRepository> {
+                val remoteUrl = resolveProperty("MVN_REPOSITORY_URL", "mvnRepositoryUrl") ?: ""
+                if (remoteUrl.length > 0) {
+                    maven {
+                        name = "maven-remote"
+                        url = URI.create(remoteUrl)
+                    }
+                }
+            }
             maven {
                 name = "ome.maven"
                 url = URI.create("https://artifacts.openmicroscopy.org/artifactory/maven/")

--- a/src/main/kotlin/org/openmicroscopy/AdditionalRepositoriesPlugin.kt
+++ b/src/main/kotlin/org/openmicroscopy/AdditionalRepositoriesPlugin.kt
@@ -2,25 +2,20 @@ package org.openmicroscopy
 
 import org.gradle.api.Plugin
 import org.gradle.api.Project
-import org.gradle.api.artifacts.repositories.MavenArtifactRepository
-import org.gradle.kotlin.dsl.closureOf
 import org.gradle.kotlin.dsl.repositories
-import org.openmicroscopy.PluginHelper.Companion.resolveProperty
+import org.openmicroscopy.PluginHelper.Companion.createArtifactoryMavenRepo
+import org.openmicroscopy.PluginHelper.Companion.createGitlabMavenRepo
+import org.openmicroscopy.PluginHelper.Companion.createStandardMavenRepo
+import org.openmicroscopy.PluginHelper.Companion.safeAdd
 import java.net.URI
 
 class AdditionalRepositoriesPlugin : Plugin<Project> {
     override fun apply(project: Project): Unit = project.run {
         repositories {
-            // Add artifactory and maven repositories if defined
-            closureOf<MavenArtifactRepository> {
-                val remoteUrl = resolveProperty("MVN_REPOSITORY_URL", "mvnRepositoryUrl") ?: ""
-                if (remoteUrl.length > 0) {
-                    maven {
-                        name = "maven-remote"
-                        url = URI.create(remoteUrl)
-                    }
-                }
-            }
+            safeAdd(createArtifactoryMavenRepo())
+            safeAdd(createGitlabMavenRepo())
+            safeAdd(createStandardMavenRepo())
+
             maven {
                 name = "ome.maven"
                 url = URI.create("https://artifacts.openmicroscopy.org/artifactory/maven/")

--- a/src/main/kotlin/org/openmicroscopy/PluginHelper.kt
+++ b/src/main/kotlin/org/openmicroscopy/PluginHelper.kt
@@ -75,7 +75,7 @@ class PluginHelper {
                     resolveProperty("MAVEN_SNAPSHOTS_REPO_URL", "mavenSnapshotsRepoUrl")
 
             val chosenUrl =
-                    (if (hasProperty("release")) snapshotsRepoUrl else releasesRepoUrl) ?: return null
+                    (if (hasProperty("release")) releasesRepoUrl else snapshotsRepoUrl) ?: return null
 
             return repositories.maven {
                 url = URI.create(chosenUrl)

--- a/src/main/kotlin/org/openmicroscopy/PluginHelper.kt
+++ b/src/main/kotlin/org/openmicroscopy/PluginHelper.kt
@@ -70,15 +70,15 @@ class PluginHelper {
 
         fun Project.createStandardMavenRepo(): MavenArtifactRepository? {
             val releasesRepoUrl =
-                    URI(resolveProperty("MAVEN_RELEASES_REPO_URL", "mavenReleasesRepoUrl"))
+                    resolveProperty("MAVEN_RELEASES_REPO_URL", "mavenReleasesRepoUrl")
             val snapshotsRepoUrl =
-                    URI(resolveProperty("MAVEN_SNAPSHOTS_REPO_URL", "mavenSnapshotsRepoUrl"))
+                    resolveProperty("MAVEN_SNAPSHOTS_REPO_URL", "mavenSnapshotsRepoUrl")
 
             val chosenUrl =
                     (if (hasProperty("release")) snapshotsRepoUrl else releasesRepoUrl) ?: return null
 
             return repositories.maven {
-                url = chosenUrl
+                url = URI.create(chosenUrl)
                 name = "maven"
                 credentials {
                     username = resolveProperty("MAVEN_USER", "mavenUser")

--- a/src/main/kotlin/org/openmicroscopy/PluginHelper.kt
+++ b/src/main/kotlin/org/openmicroscopy/PluginHelper.kt
@@ -13,6 +13,7 @@ import org.gradle.api.publish.maven.MavenPom
 import org.gradle.kotlin.dsl.*
 import java.net.URI
 
+// Note: this should be copied to build.gradle.kts to ensure this plugin can publish itself
 class PluginHelper {
     companion object {
         fun getRuntimeClasspathConfiguration(project: Project): Configuration? =

--- a/src/main/kotlin/org/openmicroscopy/PluginHelper.kt
+++ b/src/main/kotlin/org/openmicroscopy/PluginHelper.kt
@@ -1,10 +1,16 @@
 package org.openmicroscopy
 
 import com.google.common.base.CaseFormat
+import org.gradle.api.Action
 import org.gradle.api.Project
 import org.gradle.api.artifacts.Configuration
+import org.gradle.api.artifacts.repositories.ArtifactRepository
+import org.gradle.api.artifacts.repositories.MavenArtifactRepository
+import org.gradle.api.credentials.HttpHeaderCredentials
 import org.gradle.api.plugins.JavaPlugin
 import org.gradle.api.publish.maven.MavenPom
+import org.gradle.kotlin.dsl.*
+import java.net.URI
 
 class PluginHelper {
     companion object {
@@ -19,17 +25,67 @@ class PluginHelper {
             }
         }
 
+        fun Project.createArtifactoryMavenRepo(): ArtifactRepository? {
+            val artiUrl =
+                    resolveProperty("ARTIFACTORY_URL", "artifactoryUrl") ?: return null
+
+            return repositories.maven {
+                name = "artifactory"
+                url = URI.create(artiUrl)
+                credentials {
+                    username = resolveProperty("ARTIFACTORY_USER", "artifactoryUser")
+                    password = resolveProperty("ARTIFACTORY_PASSWORD", "artifactoryPassword")
+                }
+            }
+        }
+
+        fun Project.createGitlabMavenRepo(): MavenArtifactRepository {
+            return repositories.maven {
+                name = "gitlab"
+                url = URI(resolveProperty("GITLAB_URL", "gitlabUrl"))
+                credentials(HttpHeaderCredentials::class, Action {
+                    // Token specified by
+                    val jobToken = System.getenv("CI_JOB_TOKEN")
+                    if (jobToken != null) {
+                        name = "Job-Token"
+                        value = jobToken
+                    } else {
+                        name = "Private-Token"
+                        value = resolveProperty("GITLAB_TOKEN", "gitlabToken")
+                    }
+                })
+            }
+        }
+
+        fun Project.createStandardMavenRepo(): MavenArtifactRepository {
+            return repositories.maven {
+                val releasesRepoUrl =
+                        URI(resolveProperty("MAVEN_RELEASES_REPO_URL", "mavenReleasesRepoUrl"))
+                val snapshotsRepoUrl =
+                        URI(resolveProperty("MAVEN_SNAPSHOTS_REPO_URL", "mavenSnapshotsRepoUrl"))
+
+                url = if (hasProperty("release")) snapshotsRepoUrl else releasesRepoUrl
+                name = "maven"
+                credentials {
+                    username = resolveProperty("MAVEN_USER", "mavenUser")
+                    password = resolveProperty("MAVEN_PASSWORD", "mavenPassword")
+                }
+            }
+        }
+
         fun Project.resolveProperty(envVarKey: String, projectPropKey: String): String? {
-            val propValue = System.getenv()[envVarKey]
+            val propValue = System.getenv(envVarKey)
             if (propValue != null) {
                 return propValue
             }
-            return findProperty(projectPropKey).toString()
+
+            return findProperty(projectPropKey)?.toString()
         }
 
         fun Project.camelCaseName(): String {
             return CaseFormat.LOWER_HYPHEN.to(CaseFormat.LOWER_CAMEL, name)
         }
     }
+
 }
 

--- a/src/main/kotlin/org/openmicroscopy/PluginPublishingPlugin.kt
+++ b/src/main/kotlin/org/openmicroscopy/PluginPublishingPlugin.kt
@@ -13,6 +13,7 @@ import org.jfrog.gradle.plugin.artifactory.ArtifactoryPlugin
 import org.jfrog.gradle.plugin.artifactory.dsl.ArtifactoryPluginConvention
 import org.jfrog.gradle.plugin.artifactory.dsl.PublisherConfig
 import org.openmicroscopy.PluginHelper.Companion.createArtifactoryMavenRepo
+import org.openmicroscopy.PluginHelper.Companion.createGitlabMavenRepo
 import org.openmicroscopy.PluginHelper.Companion.licenseGnu2
 import org.openmicroscopy.PluginHelper.Companion.resolveProperty
 
@@ -36,9 +37,8 @@ class PluginPublishingPlugin : Plugin<Project> {
         afterEvaluate {
             configure<PublishingExtension> {
                 repositories {
-                    add(createArtifactoryMavenRepo())
-                    //gitlabMavenRepo()
-                    //standardMavenRepo()
+                    createGitlabMavenRepo(this@afterEvaluate)
+                    createArtifactoryMavenRepo(this@afterEvaluate)
                 }
 
                 // pluginMaven is task created by MavenPluginPublishPlugin

--- a/src/main/kotlin/org/openmicroscopy/PluginPublishingPlugin.kt
+++ b/src/main/kotlin/org/openmicroscopy/PluginPublishingPlugin.kt
@@ -14,8 +14,10 @@ import org.jfrog.gradle.plugin.artifactory.dsl.ArtifactoryPluginConvention
 import org.jfrog.gradle.plugin.artifactory.dsl.PublisherConfig
 import org.openmicroscopy.PluginHelper.Companion.createArtifactoryMavenRepo
 import org.openmicroscopy.PluginHelper.Companion.createGitlabMavenRepo
+import org.openmicroscopy.PluginHelper.Companion.createStandardMavenRepo
 import org.openmicroscopy.PluginHelper.Companion.licenseGnu2
 import org.openmicroscopy.PluginHelper.Companion.resolveProperty
+import org.openmicroscopy.PluginHelper.Companion.safeAdd
 
 
 class PluginPublishingPlugin : Plugin<Project> {
@@ -28,7 +30,7 @@ class PluginPublishingPlugin : Plugin<Project> {
     private
     fun Project.applyJavaGradlePlugin() {
         apply<MavenPublishPlugin>()
-        // apply<ArtifactoryPlugin>()
+        apply<ArtifactoryPlugin>()
         apply<JavaGradlePluginPlugin>()
     }
 
@@ -37,8 +39,9 @@ class PluginPublishingPlugin : Plugin<Project> {
         afterEvaluate {
             configure<PublishingExtension> {
                 repositories {
-                    createGitlabMavenRepo(this@afterEvaluate)
-                    createArtifactoryMavenRepo(this@afterEvaluate)
+                    safeAdd(createArtifactoryMavenRepo())
+                    safeAdd(createGitlabMavenRepo())
+                    safeAdd(createStandardMavenRepo())
                 }
 
                 // pluginMaven is task created by MavenPluginPublishPlugin

--- a/src/main/kotlin/org/openmicroscopy/PluginPublishingPlugin.kt
+++ b/src/main/kotlin/org/openmicroscopy/PluginPublishingPlugin.kt
@@ -3,10 +3,13 @@ package org.openmicroscopy
 import groovy.lang.GroovyObject
 import org.gradle.api.Plugin
 import org.gradle.api.Project
+import org.gradle.api.artifacts.dsl.RepositoryHandler
+import org.gradle.api.artifacts.repositories.MavenArtifactRepository
 import org.gradle.api.plugins.GroovyPlugin
 import org.gradle.api.publish.PublishingExtension
 import org.gradle.api.publish.maven.MavenPublication
 import org.gradle.api.publish.maven.plugins.MavenPublishPlugin
+import org.gradle.internal.impldep.org.apache.maven.Maven
 import org.gradle.kotlin.dsl.apply
 import org.gradle.kotlin.dsl.configure
 import org.gradle.kotlin.dsl.delegateClosureOf
@@ -18,6 +21,7 @@ import org.jfrog.gradle.plugin.artifactory.dsl.ArtifactoryPluginConvention
 import org.jfrog.gradle.plugin.artifactory.dsl.PublisherConfig
 import org.openmicroscopy.PluginHelper.Companion.licenseGnu2
 import org.openmicroscopy.PluginHelper.Companion.resolveProperty
+import java.net.URI
 
 class PluginPublishingPlugin : Plugin<Project> {
     override fun apply(project: Project): Unit = project.run {
@@ -37,6 +41,17 @@ class PluginPublishingPlugin : Plugin<Project> {
     fun Project.configurePluginMaven() {
         afterEvaluate {
             configure<PublishingExtension> {
+                repositories {
+                    maven {
+                        name = "remote"
+                        url = URI(resolveProperty("ARTIFACTORY_URL", "artifactoryUrl"))
+                        credentials {
+                            username = resolveProperty("ARTIFACTORY_USER", "artifactoryUser")
+                            password = resolveProperty("ARTIFACTORY_PASSWORD", "artifactoryPassword")
+                        }
+                    }
+                }
+
                 // pluginMaven is task created by MavenPluginPublishPlugin
                 publications.getByName<MavenPublication>("pluginMaven") {
                     artifact(tasks.getByName("sourcesJar"))

--- a/src/main/kotlin/org/openmicroscopy/PluginPublishingPlugin.kt
+++ b/src/main/kotlin/org/openmicroscopy/PluginPublishingPlugin.kt
@@ -3,25 +3,19 @@ package org.openmicroscopy
 import groovy.lang.GroovyObject
 import org.gradle.api.Plugin
 import org.gradle.api.Project
-import org.gradle.api.artifacts.dsl.RepositoryHandler
-import org.gradle.api.artifacts.repositories.MavenArtifactRepository
 import org.gradle.api.plugins.GroovyPlugin
 import org.gradle.api.publish.PublishingExtension
 import org.gradle.api.publish.maven.MavenPublication
 import org.gradle.api.publish.maven.plugins.MavenPublishPlugin
-import org.gradle.internal.impldep.org.apache.maven.Maven
-import org.gradle.kotlin.dsl.apply
-import org.gradle.kotlin.dsl.configure
-import org.gradle.kotlin.dsl.delegateClosureOf
-import org.gradle.kotlin.dsl.getByName
-import org.gradle.kotlin.dsl.withType
+import org.gradle.kotlin.dsl.*
 import org.gradle.plugin.devel.plugins.JavaGradlePluginPlugin
 import org.jfrog.gradle.plugin.artifactory.ArtifactoryPlugin
 import org.jfrog.gradle.plugin.artifactory.dsl.ArtifactoryPluginConvention
 import org.jfrog.gradle.plugin.artifactory.dsl.PublisherConfig
+import org.openmicroscopy.PluginHelper.Companion.createArtifactoryMavenRepo
 import org.openmicroscopy.PluginHelper.Companion.licenseGnu2
 import org.openmicroscopy.PluginHelper.Companion.resolveProperty
-import java.net.URI
+
 
 class PluginPublishingPlugin : Plugin<Project> {
     override fun apply(project: Project): Unit = project.run {
@@ -33,7 +27,7 @@ class PluginPublishingPlugin : Plugin<Project> {
     private
     fun Project.applyJavaGradlePlugin() {
         apply<MavenPublishPlugin>()
-        apply<ArtifactoryPlugin>()
+        // apply<ArtifactoryPlugin>()
         apply<JavaGradlePluginPlugin>()
     }
 
@@ -42,14 +36,9 @@ class PluginPublishingPlugin : Plugin<Project> {
         afterEvaluate {
             configure<PublishingExtension> {
                 repositories {
-                    maven {
-                        name = "remote"
-                        url = URI(resolveProperty("ARTIFACTORY_URL", "artifactoryUrl"))
-                        credentials {
-                            username = resolveProperty("ARTIFACTORY_USER", "artifactoryUser")
-                            password = resolveProperty("ARTIFACTORY_PASSWORD", "artifactoryPassword")
-                        }
-                    }
+                    add(createArtifactoryMavenRepo())
+                    //gitlabMavenRepo()
+                    //standardMavenRepo()
                 }
 
                 // pluginMaven is task created by MavenPluginPublishPlugin
@@ -70,15 +59,17 @@ class PluginPublishingPlugin : Plugin<Project> {
     }
 
     fun Project.configureArtifactoryExtension() {
-        configure<ArtifactoryPluginConvention> {
-            publish(delegateClosureOf<PublisherConfig> {
-                setContextUrl(resolveProperty("ARTIFACTORY_URL", "artifactoryUrl"))
-                repository(delegateClosureOf<GroovyObject> {
-                    setProperty("repoKey", resolveProperty("ARTIFACTORY_REPOKEY", "artifactoryRepokey"))
-                    setProperty("username", resolveProperty("ARTIFACTORY_USER", "artifactoryUser"))
-                    setProperty("password", resolveProperty("ARTIFACTORY_PASSWORD", "artifactoryPassword"))
+        plugins.withType<ArtifactoryPlugin> {
+            configure<ArtifactoryPluginConvention> {
+                publish(delegateClosureOf<PublisherConfig> {
+                    setContextUrl(resolveProperty("ARTIFACTORY_URL", "artifactoryUrl"))
+                    repository(delegateClosureOf<GroovyObject> {
+                        setProperty("repoKey", resolveProperty("ARTIFACTORY_REPOKEY", "artifactoryRepokey"))
+                        setProperty("username", resolveProperty("ARTIFACTORY_USER", "artifactoryUser"))
+                        setProperty("password", resolveProperty("ARTIFACTORY_PASSWORD", "artifactoryPassword"))
+                    })
                 })
-            })
+            }
         }
     }
 }

--- a/src/main/kotlin/org/openmicroscopy/PublishingPlugin.kt
+++ b/src/main/kotlin/org/openmicroscopy/PublishingPlugin.kt
@@ -10,22 +10,17 @@ import org.gradle.api.publish.PublishingExtension
 import org.gradle.api.publish.maven.MavenPublication
 import org.gradle.api.publish.maven.plugins.MavenPublishPlugin
 import org.gradle.api.tasks.bundling.Jar
-import org.gradle.kotlin.dsl.apply
-import org.gradle.kotlin.dsl.configure
-import org.gradle.kotlin.dsl.create
-import org.gradle.kotlin.dsl.delegateClosureOf
-import org.gradle.kotlin.dsl.get
+import org.gradle.kotlin.dsl.*
 import org.jfrog.gradle.plugin.artifactory.ArtifactoryPlugin
 import org.jfrog.gradle.plugin.artifactory.dsl.ArtifactoryPluginConvention
 import org.jfrog.gradle.plugin.artifactory.dsl.PublisherConfig
+import org.openmicroscopy.PluginHelper.Companion.camelCaseName
 import org.openmicroscopy.PluginHelper.Companion.getRuntimeClasspathConfiguration
 import org.openmicroscopy.PluginHelper.Companion.licenseGnu2
-import java.net.URI
+import org.openmicroscopy.PluginHelper.Companion.resolveProperty
 import java.text.SimpleDateFormat
 import java.util.*
-import org.gradle.kotlin.dsl.*
-import org.openmicroscopy.PluginHelper.Companion.camelCaseName
-import org.openmicroscopy.PluginHelper.Companion.resolveProperty
+import kotlin.collections.set
 
 
 class PublishingPlugin : Plugin<Project> {
@@ -39,7 +34,7 @@ class PublishingPlugin : Plugin<Project> {
     private
     fun Project.applyPublishingPlugin() {
         apply<MavenPublishPlugin>()
-        apply<ArtifactoryPlugin>()
+        // apply<ArtifactoryPlugin>()
     }
 
     // ORIGINAL
@@ -76,14 +71,9 @@ class PublishingPlugin : Plugin<Project> {
     fun Project.configurePublishingExtension() {
         configure<PublishingExtension> {
             repositories {
-                maven {
-                    name = "remote"
-                    url = URI(resolveProperty("ARTIFACTORY_URL", "artifactoryUrl"))
-                    credentials {
-                        username = resolveProperty("ARTIFACTORY_USER", "artifactoryUser")
-                        password = resolveProperty("ARTIFACTORY_PASSWORD", "artifactoryPassword")
-                    }
-                }
+                //artifactoryMavenRepo()
+                //gitlabMavenRepo()
+                //standardMavenRepo()
             }
 
             publications {
@@ -121,15 +111,17 @@ class PublishingPlugin : Plugin<Project> {
 
     private
     fun Project.configureArtifactoryExtension() {
-        configure<ArtifactoryPluginConvention> {
-            publish(delegateClosureOf<PublisherConfig> {
-                setContextUrl(resolveProperty("ARTIFACTORY_URL", "artifactoryUrl"))
-                repository(delegateClosureOf<GroovyObject> {
-                    setProperty("repoKey", resolveProperty("ARTIFACTORY_REPOKEY", "artifactoryRepokey"))
-                    setProperty("username", resolveProperty("ARTIFACTORY_USER", "artifactoryUser"))
-                    setProperty("password", resolveProperty("ARTIFACTORY_PASSWORD", "artifactoryPassword"))
+        plugins.withType<ArtifactoryPlugin> {
+            configure<ArtifactoryPluginConvention> {
+                publish(delegateClosureOf<PublisherConfig> {
+                    setContextUrl(resolveProperty("ARTIFACTORY_URL", "artifactoryUrl"))
+                    repository(delegateClosureOf<GroovyObject> {
+                        setProperty("repoKey", resolveProperty("ARTIFACTORY_REPOKEY", "artifactoryRepokey"))
+                        setProperty("username", resolveProperty("ARTIFACTORY_USER", "artifactoryUser"))
+                        setProperty("password", resolveProperty("ARTIFACTORY_PASSWORD", "artifactoryPassword"))
+                    })
                 })
-            })
+            }
         }
     }
 

--- a/src/main/kotlin/org/openmicroscopy/PublishingPlugin.kt
+++ b/src/main/kotlin/org/openmicroscopy/PublishingPlugin.kt
@@ -20,6 +20,7 @@ import org.jfrog.gradle.plugin.artifactory.dsl.ArtifactoryPluginConvention
 import org.jfrog.gradle.plugin.artifactory.dsl.PublisherConfig
 import org.openmicroscopy.PluginHelper.Companion.getRuntimeClasspathConfiguration
 import org.openmicroscopy.PluginHelper.Companion.licenseGnu2
+import java.net.URI
 import java.text.SimpleDateFormat
 import java.util.*
 import org.gradle.kotlin.dsl.*
@@ -74,6 +75,17 @@ class PublishingPlugin : Plugin<Project> {
     private
     fun Project.configurePublishingExtension() {
         configure<PublishingExtension> {
+            repositories {
+                maven {
+                    name = "remote"
+                    url = URI(resolveProperty("ARTIFACTORY_URL", "artifactoryUrl"))
+                    credentials {
+                        username = resolveProperty("ARTIFACTORY_USER", "artifactoryUser")
+                        password = resolveProperty("ARTIFACTORY_PASSWORD", "artifactoryPassword")
+                    }
+                }
+            }
+
             publications {
                 create<MavenPublication>(camelCaseName()) {
                     plugins.withType<JavaPlugin> {

--- a/src/main/kotlin/org/openmicroscopy/PublishingPlugin.kt
+++ b/src/main/kotlin/org/openmicroscopy/PublishingPlugin.kt
@@ -15,9 +15,13 @@ import org.jfrog.gradle.plugin.artifactory.ArtifactoryPlugin
 import org.jfrog.gradle.plugin.artifactory.dsl.ArtifactoryPluginConvention
 import org.jfrog.gradle.plugin.artifactory.dsl.PublisherConfig
 import org.openmicroscopy.PluginHelper.Companion.camelCaseName
+import org.openmicroscopy.PluginHelper.Companion.createArtifactoryMavenRepo
+import org.openmicroscopy.PluginHelper.Companion.createGitlabMavenRepo
+import org.openmicroscopy.PluginHelper.Companion.createStandardMavenRepo
 import org.openmicroscopy.PluginHelper.Companion.getRuntimeClasspathConfiguration
 import org.openmicroscopy.PluginHelper.Companion.licenseGnu2
 import org.openmicroscopy.PluginHelper.Companion.resolveProperty
+import org.openmicroscopy.PluginHelper.Companion.safeAdd
 import java.text.SimpleDateFormat
 import java.util.*
 import kotlin.collections.set
@@ -34,7 +38,7 @@ class PublishingPlugin : Plugin<Project> {
     private
     fun Project.applyPublishingPlugin() {
         apply<MavenPublishPlugin>()
-        // apply<ArtifactoryPlugin>()
+        apply<ArtifactoryPlugin>()
     }
 
     // ORIGINAL
@@ -71,9 +75,9 @@ class PublishingPlugin : Plugin<Project> {
     fun Project.configurePublishingExtension() {
         configure<PublishingExtension> {
             repositories {
-                //artifactoryMavenRepo()
-                //gitlabMavenRepo()
-                //standardMavenRepo()
+                safeAdd(createArtifactoryMavenRepo())
+                safeAdd(createGitlabMavenRepo())
+                safeAdd(createStandardMavenRepo())
             }
 
             publications {


### PR DESCRIPTION
- Fixes a couple of bugs
- Adds Artifactory/Gitlab/Maven repos to build.gradle.kts so this plugin can publish itself
- Adds Artifactory/Gitlab/Maven repos as source repos on the assumption that if you have a repo you want to publish to you also want to pull artefacts from it. If the repo is public you can just provide the URL and ignore the user/password.